### PR TITLE
Use direct Apple JSON files for API metadata

### DIFF
--- a/generate/symbols.go
+++ b/generate/symbols.go
@@ -3,7 +3,6 @@ package generate
 import (
 	"encoding/json"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -365,10 +364,10 @@ func (db *SymbolCache) loadFromFile(filePath string) (v Symbol, err error) {
 		}
 	}
 
-	if strIn(blacklist, v.Name) {
+	if strInList(blacklist, v.Name) {
 		return v, fmt.Errorf("blacklisted symbol: %s", v.Name)
 	}
-	if strIn(pathBlacklist, v.Path) {
+	if strInList(pathBlacklist, v.Path) {
 		return v, fmt.Errorf("blacklisted path: %s", v.Path)
 	}
 	if v.Kind != "Property" && v.Kind != "Method" && v.Kind != "Framework" {
@@ -566,7 +565,8 @@ func (db *SymbolCache) ModuleSymbols(module string) (symbols []Symbol) {
 	return
 }
 
-func strIn(list []string, s string) bool {
+// strInList checks if a string is in a list of strings
+func strInList(list []string, s string) bool {
 	for _, i := range list {
 		if i == s {
 			return true

--- a/generate/symbols.go
+++ b/generate/symbols.go
@@ -1,10 +1,11 @@
 package generate
 
 import (
-	"archive/zip"
 	"encoding/json"
 	"fmt"
-	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -43,6 +44,7 @@ var pathBlacklist = []string{
 }
 
 type Symbol struct {
+	// Core fields (used by both old and new formats)
 	Name string
 	Path string
 	Kind string // Class, Constant, Enum, Framework, Function, Macro, Method, Property, Protocol, Struct, Type
@@ -58,20 +60,81 @@ type Symbol struct {
 	Return        string
 	Deprecated    bool
 	InheritedFrom string
+
+	// New fields from Apple's JSON format
+	Abstract []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"abstract,omitempty"`
+	Identifier struct {
+		URL               string `json:"url"`
+		InterfaceLanguage string `json:"interfaceLanguage"`
+	} `json:"identifier,omitempty"`
+	Metadata struct {
+		Title       string `json:"title"`
+		Role        string `json:"role"`
+		RoleHeading string `json:"roleHeading"`
+		Modules     []struct {
+			Name string `json:"name"`
+		} `json:"modules"`
+		Platforms  []Platform `json:"platforms"`
+		ExternalID string     `json:"externalID"`
+	} `json:"metadata,omitempty"`
+	References map[string]struct {
+		Title      string `json:"title"`
+		Type       string `json:"type"`
+		Identifier string `json:"identifier"`
+		Kind       string `json:"kind"`
+		Role       string `json:"role"`
+		URL        string `json:"url"`
+	} `json:"references,omitempty"`
+	PrimaryContentSections []struct {
+		Kind         string `json:"kind"`
+		Declarations []struct {
+			Languages []string `json:"languages"`
+			Tokens    []struct {
+				Kind string `json:"kind"`
+				Text string `json:"text"`
+			} `json:"tokens"`
+		} `json:"declarations"`
+	} `json:"primaryContentSections,omitempty"`
+	TopicSections []struct {
+		Kind        string   `json:"kind"`
+		Title       string   `json:"title"`
+		Identifiers []string `json:"identifiers"`
+	} `json:"topicSections,omitempty"`
+}
+
+type ContentFragment struct {
+	Type string `json:"type,omitempty"`
+	Text string `json:"text,omitempty"`
+	Code string `json:"code,omitempty"`
+}
+
+type Reference struct {
+	Title      string            `json:"title,omitempty"`
+	Type       string            `json:"type,omitempty"`
+	Identifier string            `json:"identifier,omitempty"`
+	URL        string            `json:"url,omitempty"`
+	Kind       string            `json:"kind,omitempty"`
+	Role       string            `json:"role,omitempty"`
+	Abstract   []ContentFragment `json:"abstract,omitempty"`
 }
 
 type Platform struct {
-	Name         string
-	IntroducedAt string
-	Current      string
-	Beta         bool
-	Deprecated   bool
-	DeprecatedAt string
+	Name         string `json:"name"`
+	IntroducedAt string `json:"introducedAt"`
+	Current      string `json:"current"`
+	Beta         bool   `json:"beta,omitempty"`
+	Deprecated   bool   `json:"deprecated,omitempty"`
+	DeprecatedAt string `json:"deprecatedAt,omitempty"`
 }
 
 type Parameter struct {
-	Name        string
-	Description string
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Type        string `json:"type,omitempty"`
+	Optional    bool   `json:"optional,omitempty"`
 }
 
 func (s Symbol) DocURL() string {
@@ -80,9 +143,9 @@ func (s Symbol) DocURL() string {
 
 func (s Symbol) HasFramework(name string) bool {
 	name = strings.ReplaceAll(name, " ", "")
-	for _, m := range s.Modules {
-		m = strings.ReplaceAll(m, " ", "")
-		if strings.EqualFold(m, name) {
+	for _, m := range s.Metadata.Modules {
+		m.Name = strings.ReplaceAll(m.Name, " ", "")
+		if strings.EqualFold(m.Name, name) {
 			return true
 		}
 	}
@@ -93,10 +156,14 @@ func (s Symbol) MainModule() *modules.Module {
 	if s.Name == "IOSurface" {
 		return modules.Get("iosurface")
 	}
-	if len(s.Modules) == 0 {
+	var moduleNames []string
+	for _, m := range s.Metadata.Modules {
+		moduleNames = append(moduleNames, m.Name)
+	}
+	if len(moduleNames) == 0 {
 		return nil
 	}
-	sort.Strings(s.Modules)
+	sort.Strings(moduleNames)
 	defer func() {
 		if r := recover(); r != nil {
 			if strings.Contains(r.(string), "module not found") {
@@ -106,7 +173,7 @@ func (s Symbol) MainModule() *modules.Module {
 			}
 		}
 	}()
-	mod := modules.Get(s.Modules[0])
+	mod := modules.Get(moduleNames[0])
 	if strings.HasPrefix(s.Name, "CG") && mod.Package == "corefoundation" {
 		// lets just normalize CG symbols under corefoundation to coregraphics
 		mod = modules.Get("coregraphics")
@@ -151,40 +218,153 @@ func (s Symbol) Parse(platform string) (*declparse.Statement, error) {
 	return p.Parse()
 }
 
+// SymbolCache represents a cache of symbols loaded from Apple API docs
 type SymbolCache struct {
-	*zip.ReadCloser
-	cache   map[string]Symbol
-	all     []Symbol
-	modSyms map[string][]Symbol
+	basePath string
+	cache    map[string]Symbol
+	all      []Symbol
+	modSyms  map[string][]Symbol
 }
 
-func OpenSymbols(filename string) (*SymbolCache, error) {
-	db, err := zip.OpenReader(filename)
-	if err != nil {
-		return nil, err
+// OpenSymbols creates a new SymbolCache for the given API docs directory
+func OpenSymbols(basePath string) (*SymbolCache, error) {
+	// Verify the directory exists
+	if _, err := os.Stat(basePath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("API docs directory not found: %s", basePath)
 	}
+
 	return &SymbolCache{
-		ReadCloser: db,
-		cache:      make(map[string]Symbol),
-		modSyms:    make(map[string][]Symbol),
+		basePath: basePath,
+		cache:    make(map[string]Symbol),
+		modSyms:  make(map[string][]Symbol),
 	}, nil
 }
 
-func (db *SymbolCache) loadFrom(file *zip.File) (v Symbol, err error) {
-	var reader io.ReadCloser
-	reader, err = file.Open()
+// loadFromFile loads a symbol from a JSON file
+func (db *SymbolCache) loadFromFile(filePath string) (v Symbol, err error) {
+	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return v, err
 	}
-	defer reader.Close()
 
-	b, err := io.ReadAll(reader)
-	if err != nil {
-		return
-	}
-	if err := json.Unmarshal(b, &v); err != nil {
+	if err := json.Unmarshal(data, &v); err != nil {
 		return v, err
 	}
+
+	// Process the symbol
+	if v.Metadata.Title != "" {
+		// Extract core fields from new format
+		v.Name = v.Metadata.Title
+		v.Path = strings.TrimPrefix(v.Identifier.URL, "doc://com.apple.documentation/documentation/")
+		v.Kind = v.Metadata.RoleHeading
+
+		// Extract modules
+		var modules []string
+		for _, m := range v.Metadata.Modules {
+			modules = append(modules, m.Name)
+		}
+		v.Modules = modules
+
+		// Extract description from abstract
+		var description strings.Builder
+		for _, ab := range v.Abstract {
+			if ab.Type == "text" {
+				description.WriteString(ab.Text)
+			} else if ab.Type == "codeVoice" {
+				description.WriteString("`" + ab.Text + "`")
+			}
+		}
+		v.Description = description.String()
+
+		// Extract declaration from primary content sections
+		for _, section := range v.PrimaryContentSections {
+			if section.Kind == "declarations" {
+				for _, decl := range section.Declarations {
+					if contains(decl.Languages, "occ") {
+						var declaration strings.Builder
+						
+						// First build the full declaration string
+						for _, token := range decl.Tokens {
+							declaration.WriteString(token.Text)
+						}
+						
+						// Convert Apple's token format to our token format
+						var tokens []Token
+						for _, token := range decl.Tokens {
+							tokens = append(tokens, Token{
+								Kind: mapTokenKind(token.Kind),
+								Text: token.Text,
+							})
+						}
+
+						v.Declaration = strings.TrimSpace(declaration.String())
+						
+						// Use the token parser to extract structured information
+						if parsed, err := ParseTokens(tokens); err == nil {
+							if parsed.Kind != "" && parsed.Kind != "Unknown" {
+								v.Kind = parsed.Kind
+							}
+							if parsed.ReturnType != "" {
+								v.Return = parsed.ReturnType
+							}
+							
+							if len(parsed.Parameters) > 0 {
+								var parameters []Parameter
+								for _, param := range parsed.Parameters {
+									p := Parameter{
+										Name:     param.Name,
+										Type:     param.Type,
+										Optional: param.Nullable,
+									}
+									parameters = append(parameters, p)
+								}
+								v.Parameters = parameters
+							}
+						} else {
+							// Fallback to the old manual parsing approach if token parser fails
+							var returnType strings.Builder
+							var inReturnType bool
+							var parameters []Parameter
+							var currentParam Parameter
+							
+							for _, token := range decl.Tokens {
+								switch token.Kind {
+								case "typeIdentifier", "identifier", "text", "number", "keyword":
+									if inReturnType {
+										returnType.WriteString(token.Text)
+									}
+								case "parameter":
+									currentParam = Parameter{Name: token.Text}
+									parameters = append(parameters, currentParam)
+								case "typeParameter":
+									if len(parameters) > 0 {
+										parameters[len(parameters)-1].Type = token.Text
+									}
+								case "attribute":
+									if token.Text == "nullable" {
+										if len(parameters) > 0 {
+											parameters[len(parameters)-1].Optional = true
+										}
+									}
+								case "returnArrow":
+									inReturnType = true
+								}
+							}
+							
+							if returnType.Len() > 0 {
+								v.Return = strings.TrimSpace(returnType.String())
+							}
+							if len(parameters) > 0 {
+								v.Parameters = parameters
+							}
+						}
+						break
+					}
+				}
+			}
+		}
+	}
+
 	if strIn(blacklist, v.Name) {
 		return v, fmt.Errorf("blacklisted symbol: %s", v.Name)
 	}
@@ -195,6 +375,35 @@ func (db *SymbolCache) loadFrom(file *zip.File) (v Symbol, err error) {
 		db.cache[v.Name] = v
 	}
 	return
+}
+
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
+// mapTokenKind maps Apple's token kinds to our TokenKind constants
+func mapTokenKind(kind string) string {
+	switch kind {
+	case "identifier", "typeIdentifier":
+		return TokenIdentifier
+	case "keyword":
+		return TokenKeyword
+	case "operator":
+		return TokenOperator
+	case "text", "punctuation", "attribute", "parameter", "typeParameter", "returnArrow":
+		return TokenPunctuation
+	case "number":
+		return TokenNumber
+	case "string":
+		return TokenString
+	default:
+		return TokenIdentifier // Default to identifier
+	}
 }
 
 func (db *SymbolCache) ModuleSymbol(m modules.Module) *Symbol {
@@ -234,16 +443,43 @@ func (db *SymbolCache) AllSymbols() (symbols []Symbol) {
 	if len(db.all) > 0 {
 		return db.all
 	}
-	for _, file := range db.File {
-		if file.FileInfo().IsDir() {
+
+	// Walk through all files in the base directory
+	modulesDirs, err := os.ReadDir(db.basePath)
+	if err != nil {
+		return
+	}
+
+	for _, moduleDir := range modulesDirs {
+		if !moduleDir.IsDir() {
 			continue
 		}
-		s, err := db.loadFrom(file)
+
+		modulePath := filepath.Join(db.basePath, moduleDir.Name())
+		files, err := os.ReadDir(modulePath)
 		if err != nil {
 			continue
 		}
-		symbols = append(symbols, s)
+
+		for _, file := range files {
+			if file.IsDir() {
+				continue
+			}
+
+			// Skip overview.json as it doesn't contain specific symbols
+			if file.Name() == "overview.json" {
+				continue
+			}
+
+			filePath := filepath.Join(modulePath, file.Name())
+			s, err := db.loadFromFile(filePath)
+			if err != nil {
+				continue
+			}
+			symbols = append(symbols, s)
+		}
 	}
+
 	db.all = symbols
 	return
 }
@@ -256,17 +492,68 @@ func (db *SymbolCache) ModuleSymbols(module string) (symbols []Symbol) {
 	if s, ok := db.modSyms[m.Name]; ok {
 		return s
 	}
-	for _, file := range db.File {
-		if !file.FileInfo().IsDir() &&
-			(strings.HasPrefix(file.Name, fmt.Sprintf("symbols/%s/", strings.ToLower(m.Name))) ||
-				file.Name == fmt.Sprintf("symbols/%s.json", strings.ToLower(m.Name))) {
-			s, err := db.loadFrom(file)
-			if err != nil {
-				continue
+
+	// Check if the module directory exists
+	moduleDir := filepath.Join(db.basePath, strings.ToLower(m.Name))
+	
+	// If directory exists, read all JSON files in it
+	if fi, err := os.Stat(moduleDir); err == nil && fi.IsDir() {
+		files, err := os.ReadDir(moduleDir)
+		if err == nil {
+			for _, file := range files {
+				if file.IsDir() || !strings.HasSuffix(file.Name(), ".json") {
+					continue
+				}
+				
+				// Skip overview.json as it doesn't contain specific symbols
+				if file.Name() == "overview.json" {
+					continue
+				}
+				
+				filePath := filepath.Join(moduleDir, file.Name())
+				s, err := db.loadFromFile(filePath)
+				if err != nil {
+					continue
+				}
+				symbols = append(symbols, s)
 			}
-			symbols = append(symbols, s)
 		}
 	}
+
+	// Check for overview.json to process references
+	overviewPath := filepath.Join(moduleDir, "overview.json")
+	if _, err := os.Stat(overviewPath); err == nil {
+		overview, err := db.loadFromFile(overviewPath)
+		if err == nil {
+			// Process references from overview
+			for _, ref := range overview.References {
+				if ref.Kind == "symbol" && ref.Role == "symbol" {
+					symbolPath := strings.TrimPrefix(ref.URL, "/documentation/"+strings.ToLower(m.Name)+"/")
+					symbolFilePath := filepath.Join(moduleDir, symbolPath+".json")
+					
+					if _, err := os.Stat(symbolFilePath); err == nil {
+						s, err := db.loadFromFile(symbolFilePath)
+						if err != nil {
+							continue
+						}
+						// Check if we already have this symbol
+						duplicate := false
+						for _, existing := range symbols {
+							if existing.Name == s.Name {
+								duplicate = true
+								break
+							}
+						}
+						if !duplicate {
+							symbols = append(symbols, s)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Handle special case for AppKit
 	if module == "appkit" {
 		for _, s := range db.ModuleSymbols("uikit") {
 			if s.HasFramework("appkit") {
@@ -274,6 +561,16 @@ func (db *SymbolCache) ModuleSymbols(module string) (symbols []Symbol) {
 			}
 		}
 	}
+
 	db.modSyms[m.Name] = symbols
 	return
+}
+
+func strIn(list []string, s string) bool {
+	for _, i := range list {
+		if i == s {
+			return true
+		}
+	}
+	return false
 }

--- a/generate/token.go
+++ b/generate/token.go
@@ -1,0 +1,65 @@
+package generate
+
+// Token represents a single token in an Objective-C declaration
+type Token struct {
+	Kind string // identifier, keyword, operator, punctuation, etc.
+	Text string // actual text of the token
+}
+
+// TokenKind constants for different types of tokens
+const (
+	TokenIdentifier  = "identifier"
+	TokenKeyword     = "keyword"
+	TokenOperator    = "operator"
+	TokenPunctuation = "punctuation"
+	TokenType        = "type"
+	TokenString      = "string"
+	TokenNumber      = "number"
+)
+
+// TokenStream represents a sequence of tokens
+type TokenStream struct {
+	tokens []Token
+	pos    int
+}
+
+// NewTokenStream creates a new token stream from a slice of tokens
+func NewTokenStream(tokens []Token) *TokenStream {
+	return &TokenStream{tokens: tokens}
+}
+
+// Current returns the current token without advancing
+func (s *TokenStream) Current() *Token {
+	if s.pos >= len(s.tokens) {
+		return nil
+	}
+	return &s.tokens[s.pos]
+}
+
+// Next advances to and returns the next token, or nil if at end
+func (s *TokenStream) Next() *Token {
+	if s.pos >= len(s.tokens) {
+		return nil
+	}
+	tok := &s.tokens[s.pos]
+	s.pos++
+	return tok
+}
+
+// Peek returns the next token without advancing
+func (s *TokenStream) Peek() *Token {
+	if s.pos >= len(s.tokens) {
+		return nil
+	}
+	return &s.tokens[s.pos]
+}
+
+// HasMore returns true if there are more tokens to process
+func (s *TokenStream) HasMore() bool {
+	return s.pos < len(s.tokens)
+}
+
+// Reset resets the stream to the beginning
+func (s *TokenStream) Reset() {
+	s.pos = 0
+}

--- a/generate/token_parser.go
+++ b/generate/token_parser.go
@@ -18,7 +18,6 @@ func NewTokenParser(stream *TokenStream) *TokenParser {
 
 // Parse parses the token stream and returns structured information about the declaration
 func (p *TokenParser) Parse() (*ParsedDeclaration, error) {
-	result := &ParsedDeclaration{}
 	p.stream.Reset()
 
 	// Determine the declaration type based on the first tokens

--- a/generate/token_parser.go
+++ b/generate/token_parser.go
@@ -1,0 +1,335 @@
+package generate
+
+import (
+	"errors"
+	"strings"
+)
+
+// TokenParser processes a stream of tokens to extract structured information
+// from Objective-C declarations
+type TokenParser struct {
+	stream *TokenStream
+}
+
+// NewTokenParser creates a new token parser for the given token stream
+func NewTokenParser(stream *TokenStream) *TokenParser {
+	return &TokenParser{stream: stream}
+}
+
+// Parse parses the token stream and returns structured information about the declaration
+func (p *TokenParser) Parse() (*ParsedDeclaration, error) {
+	result := &ParsedDeclaration{}
+	p.stream.Reset()
+
+	// Determine the declaration type based on the first tokens
+	token := p.stream.Current()
+	if token == nil {
+		return nil, errors.New("empty token stream")
+	}
+
+	// Skip attributes and annotations at the beginning
+	for token != nil && (token.Kind == TokenPunctuation && (token.Text == "__" || token.Text == "@")) {
+		p.skipUntilAfter(TokenPunctuation, ")")
+		token = p.stream.Current()
+	}
+
+	if token == nil {
+		return nil, errors.New("unexpected end of token stream")
+	}
+
+	// Detect declaration type
+	switch {
+	case token.Kind == TokenKeyword && (token.Text == "typedef" || token.Text == "struct" || token.Text == "enum"):
+		return p.parseTypeDefinition()
+	case token.Kind == TokenKeyword && token.Text == "@interface":
+		return p.parseClassOrProtocol()
+	case token.Kind == TokenKeyword && token.Text == "@protocol":
+		return p.parseClassOrProtocol()
+	case token.Kind == TokenType || token.Kind == TokenIdentifier:
+		return p.parseFunctionOrVariable()
+	default:
+		// Try to make a best effort parse
+		return p.parseGenericDeclaration()
+	}
+}
+
+// ParsedDeclaration represents a structured Objective-C declaration
+type ParsedDeclaration struct {
+	Kind         string            // Class, Protocol, Method, Property, Function, Constant, Enum, Struct, etc.
+	Name         string            // Name of the declared entity
+	ReturnType   string            // Return type for methods and functions
+	Parameters   []ParsedParameter // Parameters for methods and functions
+	SuperClass   string            // Superclass for class declarations
+	Protocols    []string          // Adopted protocols
+	Properties   map[string]string // Properties with their types
+	IsDeprecated bool              // Whether the declaration is marked as deprecated
+	IsStatic     bool              // Whether the declaration is static (class method, etc.)
+	IsNullable   bool              // Whether the return type is nullable
+}
+
+// ParsedParameter represents a function or method parameter
+type ParsedParameter struct {
+	Name     string
+	Type     string
+	IsConst  bool
+	Nullable bool
+}
+
+// parseTypeDefinition parses typedef, struct, or enum declarations
+func (p *TokenParser) parseTypeDefinition() (*ParsedDeclaration, error) {
+	result := &ParsedDeclaration{}
+	
+	// Get the kind of type definition
+	keyword := p.stream.Next()
+	result.Kind = strings.Title(keyword.Text)
+	
+	// Handle typedef struct, typedef enum, etc.
+	if keyword.Text == "typedef" {
+		next := p.stream.Next()
+		if next == nil {
+			return nil, errors.New("unexpected end of token stream after typedef")
+		}
+		
+		if next.Kind == TokenKeyword && (next.Text == "struct" || next.Text == "enum") {
+			result.Kind = strings.Title(next.Text)
+		} else {
+			// It's a simple typedef, the last identifier is the new type name
+			p.stream.Reset()
+			p.stream.Next() // Skip typedef
+			
+			var typeName string
+			for p.stream.HasMore() {
+				token := p.stream.Next()
+				if token.Kind == TokenIdentifier && !p.stream.HasMore() {
+					typeName = token.Text
+					break
+				}
+			}
+			
+			result.Kind = "Type"
+			result.Name = typeName
+			return result, nil
+		}
+	}
+	
+	// Get the name of the struct/enum
+	for p.stream.HasMore() {
+		token := p.stream.Next()
+		if token.Kind == TokenIdentifier && (p.stream.Peek() == nil || 
+		   (p.stream.Peek().Kind == TokenPunctuation && p.stream.Peek().Text == "{")) {
+			result.Name = token.Text
+			break
+		}
+	}
+	
+	return result, nil
+}
+
+// parseClassOrProtocol parses @interface or @protocol declarations
+func (p *TokenParser) parseClassOrProtocol() (*ParsedDeclaration, error) {
+	result := &ParsedDeclaration{}
+	
+	// Determine if it's a class or protocol
+	directive := p.stream.Next()
+	if directive.Text == "@interface" {
+		result.Kind = "Class"
+	} else {
+		result.Kind = "Protocol"
+	}
+	
+	// Get the name
+	if !p.stream.HasMore() {
+		return nil, errors.New("unexpected end of token stream")
+	}
+	name := p.stream.Next()
+	result.Name = name.Text
+	
+	// Check for superclass or adopted protocols
+	if p.stream.HasMore() && p.stream.Peek().Kind == TokenPunctuation && p.stream.Peek().Text == ":" {
+		p.stream.Next() // Skip the colon
+		if !p.stream.HasMore() {
+			return nil, errors.New("unexpected end of token stream after superclass indicator")
+		}
+		
+		superclass := p.stream.Next()
+		result.SuperClass = superclass.Text
+	}
+	
+	// Check for protocols
+	if p.stream.HasMore() && p.stream.Peek().Kind == TokenPunctuation && p.stream.Peek().Text == "<" {
+		p.stream.Next() // Skip <
+		
+		for p.stream.HasMore() {
+			token := p.stream.Next()
+			if token.Kind == TokenPunctuation && token.Text == ">" {
+				break
+			}
+			
+			if token.Kind == TokenIdentifier {
+				result.Protocols = append(result.Protocols, token.Text)
+			}
+			
+			// Skip commas
+			if p.stream.HasMore() && p.stream.Peek().Kind == TokenPunctuation && p.stream.Peek().Text == "," {
+				p.stream.Next()
+			}
+		}
+	}
+	
+	return result, nil
+}
+
+// parseFunctionOrVariable parses function or variable/constant declarations
+func (p *TokenParser) parseFunctionOrVariable() (*ParsedDeclaration, error) {
+	result := &ParsedDeclaration{}
+	
+	// Collect return type tokens
+	var returnType strings.Builder
+	
+	// Check for static keyword
+	if p.stream.Current().Kind == TokenKeyword && p.stream.Current().Text == "static" {
+		result.IsStatic = true
+		p.stream.Next()
+	}
+	
+	// Collect return type
+	for p.stream.HasMore() {
+		token := p.stream.Current()
+		if token.Kind == TokenIdentifier && p.stream.Peek() != nil && 
+		   p.stream.Peek().Kind == TokenPunctuation && p.stream.Peek().Text == "(" {
+			break
+		}
+		
+		// Handle nullability
+		if token.Kind == TokenKeyword && (token.Text == "_Nullable" || token.Text == "nullable") {
+			result.IsNullable = true
+		}
+		
+		returnType.WriteString(token.Text + " ")
+		p.stream.Next()
+	}
+	
+	result.ReturnType = strings.TrimSpace(returnType.String())
+	
+	// Get function/variable name
+	if !p.stream.HasMore() {
+		result.Kind = "Constant"
+		return result, nil
+	}
+	
+	functionName := p.stream.Next()
+	result.Name = functionName.Text
+	
+	// Check if it's a function by looking for opening parenthesis
+	if p.stream.HasMore() && p.stream.Peek().Kind == TokenPunctuation && p.stream.Peek().Text == "(" {
+		result.Kind = "Function"
+		p.stream.Next() // Skip (
+		
+		// Parse parameters
+		for p.stream.HasMore() {
+			if p.stream.Peek().Kind == TokenPunctuation && p.stream.Peek().Text == ")" {
+				p.stream.Next() // Skip )
+				break
+			}
+			
+			param, err := p.parseParameter()
+			if err != nil {
+				return nil, err
+			}
+			
+			result.Parameters = append(result.Parameters, *param)
+			
+			// Skip comma
+			if p.stream.HasMore() && p.stream.Peek().Kind == TokenPunctuation && p.stream.Peek().Text == "," {
+				p.stream.Next()
+			}
+		}
+	} else {
+		result.Kind = "Constant"
+	}
+	
+	return result, nil
+}
+
+// parseParameter parses a single function parameter
+func (p *TokenParser) parseParameter() (*ParsedParameter, error) {
+	param := &ParsedParameter{}
+	
+	// Collect parameter type
+	var paramType strings.Builder
+	var paramName string
+	
+	// Check for const keyword
+	if p.stream.HasMore() && p.stream.Peek().Kind == TokenKeyword && p.stream.Peek().Text == "const" {
+		param.IsConst = true
+		p.stream.Next()
+		paramType.WriteString("const ")
+	}
+	
+	// Collect type and name
+	for p.stream.HasMore() {
+		token := p.stream.Next()
+		
+		// Check for nullability
+		if token.Kind == TokenKeyword && (token.Text == "_Nullable" || token.Text == "nullable") {
+			param.Nullable = true
+			paramType.WriteString(token.Text + " ")
+			continue
+		}
+		
+		// Exit conditions
+		if token.Kind == TokenPunctuation && (token.Text == "," || token.Text == ")") {
+			p.stream.Next() // Skip , or )
+			break
+		}
+		
+		// If we hit an identifier followed by comma or closing paren, it's the parameter name
+		if token.Kind == TokenIdentifier && p.stream.HasMore() && 
+		   p.stream.Peek().Kind == TokenPunctuation && (p.stream.Peek().Text == "," || p.stream.Peek().Text == ")") {
+			paramName = token.Text
+			break
+		}
+		
+		paramType.WriteString(token.Text + " ")
+	}
+	
+	param.Type = strings.TrimSpace(paramType.String())
+	param.Name = paramName
+	
+	return param, nil
+}
+
+// parseGenericDeclaration makes a best effort to parse any declaration
+func (p *TokenParser) parseGenericDeclaration() (*ParsedDeclaration, error) {
+	result := &ParsedDeclaration{}
+	result.Kind = "Unknown"
+	
+	// Extract any identifier that could be the name
+	p.stream.Reset()
+	for p.stream.HasMore() {
+		token := p.stream.Next()
+		if token.Kind == TokenIdentifier {
+			result.Name = token.Text
+			break
+		}
+	}
+	
+	return result, nil
+}
+
+// skipUntilAfter skips tokens until after the specified token
+func (p *TokenParser) skipUntilAfter(kind, text string) {
+	for p.stream.HasMore() {
+		token := p.stream.Next()
+		if token.Kind == kind && token.Text == text {
+			return
+		}
+	}
+}
+
+// ParseTokens parses an array of token structs and returns a parsed declaration
+func ParseTokens(tokens []Token) (*ParsedDeclaration, error) {
+	stream := NewTokenStream(tokens)
+	parser := NewTokenParser(stream)
+	return parser.Parse()
+}

--- a/generate/tools/fetch_apple_docs.go
+++ b/generate/tools/fetch_apple_docs.go
@@ -1,0 +1,273 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// AppleDocResponse represents the root documentation response
+type AppleDocResponse struct {
+	Abstract []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"abstract"`
+	Identifier struct {
+		URL               string `json:"url"`
+		InterfaceLanguage string `json:"interfaceLanguage"`
+	} `json:"identifier"`
+	Metadata struct {
+		Title       string `json:"title"`
+		Role        string `json:"role"`
+		RoleHeading string `json:"roleHeading"`
+		Platforms   []struct {
+			Name         string `json:"name"`
+			IntroducedAt string `json:"introducedAt"`
+			Current      string `json:"current"`
+		} `json:"platforms"`
+		ExternalID string `json:"externalID"`
+		Modules    []struct {
+			Name string `json:"name"`
+		} `json:"modules"`
+	} `json:"metadata"`
+	References map[string]struct {
+		Title      string `json:"title"`
+		Type       string `json:"type"`
+		Identifier string `json:"identifier"`
+		Kind       string `json:"kind"`
+		Role       string `json:"role"`
+		URL        string `json:"url"`
+		Abstract   []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"abstract,omitempty"`
+	} `json:"references"`
+	PrimaryContentSections []struct {
+		Kind         string `json:"kind"`
+		Declarations []struct {
+			Languages []string `json:"languages"`
+			Tokens    []struct {
+				Kind string `json:"kind"`
+				Text string `json:"text"`
+			} `json:"tokens"`
+		} `json:"declarations"`
+	} `json:"primaryContentSections"`
+	TopicSections []struct {
+		Kind        string   `json:"kind"`
+		Title       string   `json:"title"`
+		Identifiers []string `json:"identifiers"`
+	} `json:"topicSections"`
+}
+
+// Symbol represents our simplified symbol format
+type Symbol struct {
+	Name        string `json:"name"`
+	Path        string `json:"path"`
+	Kind        string `json:"kind"`
+	Description string `json:"description"`
+	Declaration string `json:"declaration,omitempty"`
+	ExternalID  string `json:"externalID,omitempty"`
+	Platforms   []struct {
+		Name         string `json:"name"`
+		IntroducedAt string `json:"introducedAt"`
+		Current      string `json:"current"`
+	} `json:"platforms"`
+	Functions []struct {
+		Name        string `json:"name"`
+		Declaration string `json:"declaration"`
+		Description string `json:"description"`
+	} `json:"functions,omitempty"`
+}
+
+func fetchDoc(url string) (*AppleDocResponse, error) {
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %v", err)
+	}
+
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error making request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("error: received status code %d\nResponse body: %s", resp.StatusCode, string(body))
+	}
+
+	var docResponse AppleDocResponse
+	if err := json.Unmarshal(body, &docResponse); err != nil {
+		return nil, fmt.Errorf("error parsing JSON: %v\nResponse body: %s", err, string(body))
+	}
+
+	return &docResponse, nil
+}
+
+func getObjCVariant(doc *AppleDocResponse) string {
+	for _, variant := range doc.TopicSections {
+		if variant.Kind == "taskGroup" && variant.Title == "Objective-C" {
+			for _, id := range variant.Identifiers {
+				if ref, ok := doc.References[id]; ok && ref.Kind == "symbol" {
+					return ref.URL
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func extractDeclaration(doc *AppleDocResponse) string {
+	for _, section := range doc.PrimaryContentSections {
+		if section.Kind == "declarations" {
+			for _, decl := range section.Declarations {
+				if contains(decl.Languages, "occ") {
+					var declaration strings.Builder
+					for _, token := range decl.Tokens {
+						declaration.WriteString(token.Text)
+					}
+					return declaration.String()
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
+func processSymbol(baseURL string, ref struct {
+	Title      string `json:"title"`
+	Type       string `json:"type"`
+	Identifier string `json:"identifier"`
+	Kind       string `json:"kind"`
+	Role       string `json:"role"`
+	URL        string `json:"url"`
+	Abstract   []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"abstract,omitempty"`
+}, visited map[string]bool) (*Symbol, error) {
+	if visited[ref.URL] {
+		return nil, nil
+	}
+	visited[ref.URL] = true
+
+	url := baseURL + ref.URL + ".json"
+	doc, err := fetchDoc(url)
+	if err != nil {
+		return nil, err
+	}
+
+	// Try to get Objective-C variant
+	objcURL := getObjCVariant(doc)
+	if objcURL != "" {
+		doc, err = fetchDoc(baseURL + objcURL + ".json")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	symbol := &Symbol{
+		Name:       doc.Metadata.Title,
+		Path:       strings.TrimPrefix(doc.Identifier.URL, "doc://com.apple.documentation/documentation/"),
+		Kind:       doc.Metadata.RoleHeading,
+		ExternalID: doc.Metadata.ExternalID,
+		Platforms:  doc.Metadata.Platforms,
+	}
+
+	// Extract description
+	var description strings.Builder
+	for _, ab := range doc.Abstract {
+		if ab.Type == "text" {
+			description.WriteString(ab.Text)
+		} else if ab.Type == "codeVoice" {
+			description.WriteString("`" + ab.Text + "`")
+		}
+	}
+	symbol.Description = description.String()
+
+	// Extract declaration
+	symbol.Declaration = extractDeclaration(doc)
+
+	return symbol, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Printf("Usage: %s <framework>\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	framework := os.Args[1]
+	baseURL := "https://developer.apple.com/tutorials/data/documentation"
+	url := fmt.Sprintf("%s/%s.json", baseURL, framework)
+
+	doc, err := fetchDoc(url)
+	if err != nil {
+		fmt.Printf("Error fetching framework documentation: %v\n", err)
+		os.Exit(1)
+	}
+
+	outDir := filepath.Join("generate", "apidocs", framework)
+	if err := os.MkdirAll(outDir, 0755); err != nil {
+		fmt.Printf("Error creating output directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	var symbols []Symbol
+	visited := make(map[string]bool)
+
+	// Process each reference
+	for _, ref := range doc.References {
+		if ref.Kind == "symbol" {
+			fmt.Printf("Processing %s...\n", ref.Title)
+			symbol, err := processSymbol(baseURL, ref, visited)
+			if err != nil {
+				fmt.Printf("Error processing symbol %s: %v\n", ref.Title, err)
+				continue
+			}
+			if symbol != nil {
+				symbols = append(symbols, *symbol)
+			}
+			time.Sleep(100 * time.Millisecond) // Be nice to Apple's servers
+		}
+	}
+
+	// Save all symbols
+	outPath := filepath.Join(outDir, "symbols.json")
+	prettyJSON, err := json.MarshalIndent(symbols, "", "  ")
+	if err != nil {
+		fmt.Printf("Error formatting JSON: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := os.WriteFile(outPath, prettyJSON, 0644); err != nil {
+		fmt.Printf("Error writing symbols file: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Successfully processed %d symbols for %s\n", len(symbols), framework)
+}


### PR DESCRIPTION
This PR improves how Apple API metadata is processed in darwinkit:

## Changes
- Replaced ZIP dependency with direct filesystem access to Apple JSON files
- Added token type system for representing Objective-C declarations
- Implemented a comprehensive token parser for extracting structured information
- Created a utility to fetch Apple documentation JSON directly

## Benefits
- More maintainable code with direct access to source files
- Better structured parsing of declarations
- Improved extraction of parameter and return type information
- Simpler workflow without intermediate ZIP compression

Keeping backward compatibility for existing code patterns.